### PR TITLE
Improve aggregator error reporting

### DIFF
--- a/.github/workflows/dismal_json.yml
+++ b/.github/workflows/dismal_json.yml
@@ -1,4 +1,4 @@
-name: Run Python File
+name: Run Aggregator
 
 on:
   push:
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out this repo
-      uses: actions/checkout@v2 # checkout the repository content to github runner.
+      uses: actions/checkout@v2
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.12 #install the python needed
+        python-version: 3.12
     - run: pip install -r requirements.txt
-    - name: Run hello_world.py
+    - name: Run aggregator
       run: python dismal.py

--- a/README.md
+++ b/README.md
@@ -1,83 +1,35 @@
 # dismal
-#Econ
-https://back.nber.org/rss/new.xml
-http://export.arxiv.org/rss/econ
 
+Dismal is a lightweight RSS aggregator focused on quantitative finance, trading and machine learning news. The Python script fetches a handful of entries from each feed listed in `sources.txt` and stores them in `data.json`. The static `index.html` page displays the collected items as simple cards.
 
+## Usage
+1. Install dependencies with `pip install -r requirements.txt`.
+2. Run `python dismal.py` to generate `data.json`.
+   The script prints progress as it fetches each feed. If a feed cannot be
+   retrieved, an error message is stored in the JSON file.
+3. Open `index.html` in a browser to view the latest items. Any per-feed
+   errors will be displayed above the entries.
 
-#ML/AI/Stats/Computer Science
-http://export.arxiv.org/rss/cs
-http://export.arxiv.org/rss/q-fin 
-https://arxiv.org/help/rss
+Network restrictions may prevent the script from downloading feeds. In that
+case the JSON will contain error messages rather than entries.
 
+## Feed Sources
+A sample of the current feeds is listed below:
 
-#Space
-https://www.nasa.gov/rss/dyn/lg_image_of_the_day.rss
+- NBER: <https://back.nber.org/rss/new.xml>
+- arXiv Econ: <http://export.arxiv.org/rss/econ>
+- arXiv CS: <http://export.arxiv.org/rss/cs>
+- arXiv Quant Finance: <http://export.arxiv.org/rss/q-fin>
+- Netflix Tech Blog: <https://netflixtechblog.com/feed>
+- Lyft Engineering: <https://eng.lyft.com/feed>
+- Spotify Engineering: <https://engineering.atspotify.com/rss>
+- GitHub Blog: <https://github.blog/feed>
+- HackerNews: <https://hnrss.org/frontpage>
+- NPR: <https://feeds.npr.org/1019/rss.xml>
+- Bloomberg Markets: <https://feeds.bloomberg.com/markets/news.rss>
+- FRED Blog: <https://fredblog.stlouisfed.org/feed>
+- JMLR: <https://www.jmlr.org/jmlr.xml>
+- SEC Trading Suspensions: <https://www.sec.gov/rss/litigation/suspensions.xml>
+- NASA News: <https://www.jpl.nasa.gov/feeds/news/>
 
-
-https://www.w3schools.com/howto/howto_js_read_more.asp
-
-
-# The market will provide.
-
-https://new.ml-quant.com/public used to be free, and is just using web scrapers to provide data on papers.
-
-But I think I can make a product just as good and it can be free, maybe I'll throw my venmo on the page or something. 
-
-I don't think you need real time pulling like that site.
-
-- Github Repos marked with finance, quant, machine learning
-- Arxiv papers
-- SSRN papers
-- NBER papers:
-    - https://back.nber.org/rss/releases.xml 
-- Linkedin Posts
-- Youtube videos
-- Blogs
-    - Netflix: https://netflixtechblog.com/feed 
-    - Uber: https://www.uber.com/en-US/blog/engineering/rss
-    - Lyft: https://eng.lyft.com/feed
-    - Spotify: https://engineering.atspotify.com/rss
-    - Meta: https://engineering.fb.com/rss
-    - Airbnb: https://medium.com/feed/airbnb-engineering 
-    - Github: https://github.blog/feed 
-    - Stack Overflow: https://stackoverflow.blog/
-    - Slack: https://slack.engineering/feed 
-    - Draftkings: https://medium.com/feed/draftkings-engineering 
-    - Fanduel: https://medium.com/feed/fanduel-life/tagged/engineering 
-- News
-    - HackerNews: https://hnrss.org/frontpage 
-    - NPR: https://feeds.npr.org/1019/rss.xml
-    - Reuters: https://ir.thomsonreuters.com/rss/news-releases.xml?items=15  
-- Reddit
-- Quarterlies
-    - Bloomberg: https://duckduckgo.com/?t=ffab&q=site%3Abloomberg.com+rss&ia=web 
-    https://feeds.bloomberg.com/markets/news.rss
-    https://feeds.bloomberg.com/politics/news.rss
-    https://feeds.bloomberg.com/technology/news.rss
-    https://feeds.bloomberg.com/wealth/news.rss
-2
-    - Beige Book
-    - PWC
-    - Goldman Sachs: https://www.goldmansachs.com/intelligence/insights-articles.json 
-    - JPMorgan: https://am.jpmorgan.com/us/en/asset-management/liq/insights/portfolio-insights/asset-class-views/fixed-income/
-    - Citadel
-    - Jump
-    - FRED: https://fredblog.stlouisfed.org/feed 
-    - Chicago Booth: https://www.kentclarkcenter.org/feed 
-- Jmlr
-    - https://www.jmlr.org/jmlr.xml
-- SEC
-    - Trading suspensions: https://www.sec.gov/rss/litigation/suspensions.xml 
-- Nasa: 
-    - https://www.jpl.nasa.gov/feeds/news/
-    - Image of the day: https://www.nasa.gov/feeds/iotd-feed/
-    - Tech: https://www.nasa.gov/technology/feed/ 
-- Federal Reserve 
-    - https://www.federalreserve.gov/feeds/cp_rates.htm 
-    - https://www.federalreserve.gov/feeds/Data/CP_RATES_RIFSPPNAAD01_N.B.xml 
-- Nate Silver:
-    - https://www.natesilver.net/feed 
-- Jobs
-- Podcasts
-
+Additional feeds can be added to `sources.txt` as needed.

--- a/data.json
+++ b/data.json
@@ -1,0 +1,197 @@
+{
+  "generated": "2025-06-09T19:17:10.025444+00:00",
+  "feeds": [
+    {
+      "source": "https://back.nber.org/rss/new.xml",
+      "url": "https://back.nber.org/rss/new.xml",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    },
+    {
+      "source": "http://export.arxiv.org/rss/econ",
+      "url": "http://export.arxiv.org/rss/econ",
+      "entries": [],
+      "error": "<unknown>:2:0: syntax error; status 403"
+    },
+    {
+      "source": "http://export.arxiv.org/rss/cs",
+      "url": "http://export.arxiv.org/rss/cs",
+      "entries": [],
+      "error": "<unknown>:2:0: syntax error; status 403"
+    },
+    {
+      "source": "http://export.arxiv.org/rss/q-fin",
+      "url": "http://export.arxiv.org/rss/q-fin",
+      "entries": [],
+      "error": "<unknown>:2:0: syntax error; status 403"
+    },
+    {
+      "source": "https://arxiv.org/help/rss",
+      "url": "https://arxiv.org/help/rss",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    },
+    {
+      "source": "https://back.nber.org/rss/releases.xml",
+      "url": "https://back.nber.org/rss/releases.xml",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    },
+    {
+      "source": "https://netflixtechblog.com/feed",
+      "url": "https://netflixtechblog.com/feed",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    },
+    {
+      "source": "https://eng.lyft.com/feed",
+      "url": "https://eng.lyft.com/feed",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    },
+    {
+      "source": "https://engineering.atspotify.com/rss",
+      "url": "https://engineering.atspotify.com/rss",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    },
+    {
+      "source": "https://engineering.fb.com/rss",
+      "url": "https://engineering.fb.com/rss",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    },
+    {
+      "source": "https://medium.com/feed/airbnb-engineering",
+      "url": "https://medium.com/feed/airbnb-engineering",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    },
+    {
+      "source": "https://github.blog/feed",
+      "url": "https://github.blog/feed",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    },
+    {
+      "source": "https://stackoverflow.blog/feed",
+      "url": "https://stackoverflow.blog/feed",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    },
+    {
+      "source": "https://slack.engineering/feed",
+      "url": "https://slack.engineering/feed",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    },
+    {
+      "source": "https://medium.com/feed/draftkings-engineering",
+      "url": "https://medium.com/feed/draftkings-engineering",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    },
+    {
+      "source": "https://medium.com/feed/fanduel-life/tagged/engineering",
+      "url": "https://medium.com/feed/fanduel-life/tagged/engineering",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    },
+    {
+      "source": "https://hnrss.org/frontpage",
+      "url": "https://hnrss.org/frontpage",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    },
+    {
+      "source": "https://feeds.npr.org/1019/rss.xml",
+      "url": "https://feeds.npr.org/1019/rss.xml",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    },
+    {
+      "source": "https://ir.thomsonreuters.com/rss/news-releases.xml?items=15",
+      "url": "https://ir.thomsonreuters.com/rss/news-releases.xml?items=15",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    },
+    {
+      "source": "https://feeds.bloomberg.com/markets/news.rss",
+      "url": "https://feeds.bloomberg.com/markets/news.rss",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    },
+    {
+      "source": "https://feeds.bloomberg.com/politics/news.rss",
+      "url": "https://feeds.bloomberg.com/politics/news.rss",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    },
+    {
+      "source": "https://feeds.bloomberg.com/technology/news.rss",
+      "url": "https://feeds.bloomberg.com/technology/news.rss",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    },
+    {
+      "source": "https://feeds.bloomberg.com/wealth/news.rss",
+      "url": "https://feeds.bloomberg.com/wealth/news.rss",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    },
+    {
+      "source": "https://fredblog.stlouisfed.org/feed",
+      "url": "https://fredblog.stlouisfed.org/feed",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    },
+    {
+      "source": "https://www.jmlr.org/jmlr.xml",
+      "url": "https://www.jmlr.org/jmlr.xml",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    },
+    {
+      "source": "https://www.sec.gov/rss/litigation/suspensions.xml",
+      "url": "https://www.sec.gov/rss/litigation/suspensions.xml",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    },
+    {
+      "source": "https://www.jpl.nasa.gov/feeds/news/",
+      "url": "https://www.jpl.nasa.gov/feeds/news/",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    },
+    {
+      "source": "https://www.nasa.gov/feeds/iotd-feed/",
+      "url": "https://www.nasa.gov/feeds/iotd-feed/",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    },
+    {
+      "source": "https://www.nasa.gov/technology/feed/",
+      "url": "https://www.nasa.gov/technology/feed/",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    },
+    {
+      "source": "https://www.federalreserve.gov/feeds/cp_rates.htm",
+      "url": "https://www.federalreserve.gov/feeds/cp_rates.htm",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    },
+    {
+      "source": "https://www.federalreserve.gov/feeds/Data/CP_RATES_RIFSPPNAAD01_N.B.xml",
+      "url": "https://www.federalreserve.gov/feeds/Data/CP_RATES_RIFSPPNAAD01_N.B.xml",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    },
+    {
+      "source": "https://www.natesilver.net/feed",
+      "url": "https://www.natesilver.net/feed",
+      "entries": [],
+      "error": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+    }
+  ]
+}

--- a/dismal.py
+++ b/dismal.py
@@ -1,3 +1,61 @@
-f = open("sources.txt", "r")
-print(f.read()) 
+import json
+from datetime import datetime, timezone
 
+import feedparser
+
+SOURCES_FILE = "sources.txt"
+OUTPUT_FILE = "data.json"
+MAX_ITEMS = 5
+
+
+def load_sources(path=SOURCES_FILE):
+    with open(path, "r") as f:
+        return [line.strip() for line in f if line.strip()]
+
+
+def fetch_feed(url):
+    feed = feedparser.parse(url)
+    entries = []
+    for entry in feed.entries[:MAX_ITEMS]:
+        entries.append({
+            "title": entry.get("title", ""),
+            "link": entry.get("link", ""),
+            "published": entry.get("published", "")
+        })
+
+    error = None
+    if getattr(feed, "bozo", False):
+        error = str(getattr(feed, "bozo_exception", ""))
+    if hasattr(feed, "status") and feed.status != 200:
+        status_err = f"status {feed.status}"
+        error = f"{error}; {status_err}" if error else status_err
+
+    return {
+        "source": feed.feed.get("title", url),
+        "url": url,
+        "entries": entries,
+        "error": error,
+    }
+
+
+def main():
+    sources = load_sources()
+    aggregated = []
+    for url in sources:
+        print(f"Fetching {url}")
+        try:
+            feed = fetch_feed(url)
+            aggregated.append(feed)
+            if feed.get("error"):
+                print(f"  Error: {feed['error']}")
+            else:
+                print(f"  {len(feed['entries'])} entries")
+        except Exception as exc:
+            print(f"Failed to fetch {url}: {exc}")
+            aggregated.append({"source": url, "url": url, "entries": [], "error": str(exc)})
+    with open(OUTPUT_FILE, "w") as f:
+        json.dump({"generated": datetime.now(timezone.utc).isoformat(), "feeds": aggregated}, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/index.html
+++ b/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Dismal Aggregator</title>
+<style>
+body { font-family: Arial, sans-serif; margin: 0; padding: 20px; }
+.card { border: 1px solid #ddd; padding: 10px; margin-bottom: 10px; border-radius: 4px; }
+h2 { margin-top: 1.5em; }
+</style>
+</head>
+<body>
+<h1>Dismal Aggregator</h1>
+<div id="content">Loading...</div>
+<script>
+fetch('data.json')
+  .then(r => r.json())
+  .then(data => {
+    const container = document.getElementById('content');
+    container.textContent = '';
+    data.feeds.forEach(feed => {
+      const header = document.createElement('h2');
+      header.textContent = feed.source;
+      container.appendChild(header);
+      if (feed.error) {
+        const err = document.createElement('div');
+        err.textContent = 'Error: ' + feed.error;
+        container.appendChild(err);
+      }
+      feed.entries.forEach(entry => {
+        const card = document.createElement('div');
+        card.className = 'card';
+        card.innerHTML = `<a href="${entry.link}" target="_blank">${entry.title}</a>` +
+                         `<div>${entry.published || ''}</div>`;
+        container.appendChild(card);
+      });
+    });
+  })
+  .catch(err => {
+    document.getElementById('content').textContent = 'Failed to load data.';
+    console.error(err);
+  });
+</script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 requests==2.22.0
-gunicorn
-Flask==1.0.2
-flask_sqlalchemy
-sqlalchemy
+feedparser==6.0.11
+


### PR DESCRIPTION
## Summary
- show per-feed errors in the output JSON
- surface errors in the HTML viewer
- log feed fetching progress
- document possible network restrictions

## Testing
- `pip install -r requirements.txt`
- `python dismal.py` *(fails to fetch feeds: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68472f2ab4cc83288ed62e99176f905b